### PR TITLE
Consistent use of BigInt in setRegistry

### DIFF
--- a/src/skyid.js
+++ b/src/skyid.js
@@ -196,10 +196,10 @@ export class SkyID {
 			try {
 				let entry = await this.skynetClient.registry.getEntry(publicKey, dataKey)
 				console.log('entry', entry)
-				revision = entry.entry.revision + BigInt(1)
+				revision = BigInt(entry.entry.revision) + BigInt(1)
 			} catch (err) {
 				console.log(err)
-				revision = 0
+				revision = BigInt(0)
 			}
 		}
 


### PR DESCRIPTION
Skynet requires revision IDs to be BigInts. The problem comes when trying to set new registry entries, but not modifying existing ones:

```
Expected parameter int to be type bigint, was type number
    at t.assertUint64 (skyid.js:formatted:6724)
    at t.SkynetClient.t.setEntry (skyid.js:formatted:6454)
    at window.SkyID.setRegistry (skyid.js:formatted:10845)
```

This has come up in the context of upgrading Hacker Paste to support the latest SkyID and Skynet SDKs. Hacker Paste does nothing to manually set revision numbers. And I notice in `skyid.js` that BigInt is not used consistently, or uses implicit conversion. I propose changing the function to consistently, and explicitly, use BigInt.